### PR TITLE
More updates for Julia 1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,4 @@ addons:
         - libgmp-dev
         - libglpk-dev
 after_success:
-    - julia -e 'Pkg.add("Coverage")'
-    - julia -e 'cd(Pkg.dir("Convex")); using Coverage; Coveralls.submit(process_folder())'
+    - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder())'

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,3 @@
 julia 0.7
 MathProgBase 0.7
 DataStructures
-Compat 0.24

--- a/src/Convex.jl
+++ b/src/Convex.jl
@@ -4,7 +4,6 @@ module Convex
 import DataStructures
 using LinearAlgebra
 using SparseArrays
-using Compat
 
 global DEFAULT_SOLVER = nothing
 ### modeling framework

--- a/src/atoms/affine/diagm.jl
+++ b/src/atoms/affine/diagm.jl
@@ -49,8 +49,11 @@ function evaluate(x::DiagMatrixAtom)
   return Diagonal(vec(evaluate(x.children[1])))
 end
 
-diagm(x::AbstractExpr) = DiagMatrixAtom(x)
-Diagonal(x::AbstractExpr) = diagm(x)
+function diagm((d, x)::Pair{<:Integer, <:AbstractExpr})
+  d == 0 || throw(ArgumentError("only the main diagonal is supported"))
+  return DiagMatrixAtom(x)
+end
+Diagonal(x::AbstractExpr) = DiagMatrixAtom(x)
 
 function conic_form!(x::DiagMatrixAtom, unique_conic_forms::UniqueConicForms=UniqueConicForms())
   if !has_conic_form(unique_conic_forms, x)

--- a/src/atoms/affine/kron.jl
+++ b/src/atoms/affine/kron.jl
@@ -1,4 +1,4 @@
-import Base.kron
+import LinearAlgebra.kron
 export kron
 
 function kron(a::Value, b::AbstractExpr)

--- a/src/atoms/second_order_cone/power_to_socp.jl
+++ b/src/atoms/second_order_cone/power_to_socp.jl
@@ -12,7 +12,6 @@
 # This reduction is documented in the pdf available at
 # https://github.com/JuliaOpt/Convex.jl/raw/master/docs/supplementary/rational_to_socp.pdf
 
-using Compat
 module psocp
 
 mutable struct InequalityExpression

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,3 +1,3 @@
 GLPKMathProgInterface
 ECOS
-SCS 0.3.0 0.4.0
+SCS 0.4.0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,9 +3,10 @@ using Test
 using ECOS
 using SCS
 using GLPKMathProgInterface
+using Random
 
 # Seed random number stream to improve test reliability
-srand(2)
+Random.seed!(2)
 
 solvers = Any[]
 


### PR DESCRIPTION
Changes:
* Set the SCS lower bound for testing to 0.4.0
* `srand` is now `Random.seed!`
* Remove unused dependency on Compat
* Use the new `Pair` interface when extending `diagm`
* `kron` now lives in LinearAlgebra, not Base
* Fix coverage submission from Travis