### PR TITLE
Overload broadcasted instead of broadcast

### DIFF
--- a/src/atoms/affine/add_subtract.jl
+++ b/src/atoms/affine/add_subtract.jl
@@ -6,8 +6,7 @@
 # Please read expressions.jl first.
 #############################################################################
 
-import Base.broadcast
-export +, -, broadcast
+export +, -
 export sign, curvature, monotonicity, evaluate
 
 ### Unary Negation

--- a/src/atoms/affine/multiply_divide.jl
+++ b/src/atoms/affine/multiply_divide.jl
@@ -6,8 +6,7 @@
 # Please read expressions.jl first.
 #############################################################################
 
-import Base.broadcast
-export broadcast
+import Base.Broadcast.broadcasted
 export sign, monotonicity, curvature, evaluate, conic_form!
 
 ### Scalar and matrix multiplication
@@ -178,7 +177,7 @@ function conic_form!(x::DotMultiplyAtom, unique_conic_forms::UniqueConicForms=Un
   return get_conic_form(unique_conic_forms, x)
 end
 
-function broadcast(::typeof(*), x::Constant, y::AbstractExpr)
+function broadcasted(::typeof(*), x::Constant, y::AbstractExpr)
   if x.size == (1, 1) || y.size == (1, 1)
     return x * y
   elseif size(y,1) < size(x,1) && size(y,1) == 1
@@ -189,10 +188,10 @@ function broadcast(::typeof(*), x::Constant, y::AbstractExpr)
     return DotMultiplyAtom(x, y)
   end
 end
-broadcast(::typeof(*), y::AbstractExpr, x::Constant) = DotMultiplyAtom(x, y)
+broadcasted(::typeof(*), y::AbstractExpr, x::Constant) = DotMultiplyAtom(x, y)
 
 # if neither is a constant it's not DCP, but might be nice to support anyway for eg MultiConvex
-function broadcast(::typeof(*), x::AbstractExpr, y::AbstractExpr)
+function broadcasted(::typeof(*), x::AbstractExpr, y::AbstractExpr)
   if x.size == (1, 1) || y.size == (1, 1)
     return x * y
   elseif vexity(x) == ConstVexity()
@@ -203,7 +202,7 @@ function broadcast(::typeof(*), x::AbstractExpr, y::AbstractExpr)
     return DotMultiplyAtom(y, x)
   end
 end
-broadcast(::typeof(*), x::Value, y::AbstractExpr) = DotMultiplyAtom(Constant(x), y)
-broadcast(::typeof(*), x::AbstractExpr, y::Value) = DotMultiplyAtom(Constant(y), x)
-broadcast(::typeof(/), x::AbstractExpr, y::Value) = DotMultiplyAtom(Constant(1 ./ y), x)
+broadcasted(::typeof(*), x::Value, y::AbstractExpr) = DotMultiplyAtom(Constant(x), y)
+broadcasted(::typeof(*), x::AbstractExpr, y::Value) = DotMultiplyAtom(Constant(y), x)
+broadcasted(::typeof(/), x::AbstractExpr, y::Value) = DotMultiplyAtom(Constant(1 ./ y), x)
 # x ./ y and x / y for x constant, y variable is defined in second_order_cone.qol_elemwise.jl

--- a/src/atoms/second_order_cone/qol_elementwise.jl
+++ b/src/atoms/second_order_cone/qol_elementwise.jl
@@ -1,6 +1,6 @@
-import Base.broadcast
+import Base.Broadcast.broadcasted
 export QolElemAtom, qol_elementwise, square, sumsquares, invpos, /
-export sign, monotonicity, curvature, conic_form!, broadcast
+export sign, monotonicity, curvature, conic_form!
 
 struct QolElemAtom <: AbstractExpr
   head::Symbol
@@ -49,10 +49,10 @@ end
 
 qol_elementwise(x::AbstractExpr, y::AbstractExpr) = QolElemAtom(x, y)
 
-broadcast(::typeof(^),x::AbstractExpr,k::Int) = k==2 ? QolElemAtom(x, Constant(ones(x.size[1], x.size[2]))) : error("raising variables to powers other than 2 is not implemented")
+broadcasted(::typeof(^),x::AbstractExpr,k::Int) = k==2 ? QolElemAtom(x, Constant(ones(x.size[1], x.size[2]))) : error("raising variables to powers other than 2 is not implemented")
 
 invpos(x::AbstractExpr) = QolElemAtom(Constant(ones(x.size[1], x.size[2])), x)
-broadcast(::typeof(/), x::Value, y::AbstractExpr) = DotMultiplyAtom(Constant(x), invpos(y))
+broadcasted(::typeof(/), x::Value, y::AbstractExpr) = DotMultiplyAtom(Constant(x), invpos(y))
 /(x::Value, y::AbstractExpr) = size(y) == (1,1) ? MultiplyAtom(Constant(x), invpos(y)) : error("cannot divide by a variable of size $(size(y))")
 sumsquares(x::AbstractExpr) = square(norm2(x))
 

--- a/test/test_affine.jl
+++ b/test/test_affine.jl
@@ -1,6 +1,7 @@
 using Convex
 using Test
 import LinearAlgebra.I
+using Convex: DotMultiplyAtom
 
 TOL = 1e-3
 eye(n) = Matrix(1.0I, n, n)
@@ -246,6 +247,11 @@ eye(n) = Matrix(1.0I, n, n)
     solve!(p)
     @test p.optval ≈ 11 / 6 atol=TOL
     @test evaluate(sum((dot(/))(x, [1 2 3]))) ≈ 11 / 6 atol=TOL
+
+    # Broadcast fusion works
+    x = Variable(5, 5)
+    a = 2.0 .* x .* ones(Int, 5)
+    @test a isa DotMultiplyAtom
   end
 
   @testset "reshape atom" begin


### PR DESCRIPTION
This fixes the case where an `AbstractExpr` occurs in in a fused broadcast expression.